### PR TITLE
Feat/study page read presentation

### DIFF
--- a/client/src/composition/StudyPages/StudyPageRead/CertificateTab.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/CertificateTab.tsx
@@ -1,0 +1,114 @@
+import React, { Fragment } from 'react'
+import styled from 'styled-components'
+import CommentList from './CommentList'
+
+function CertificateTab() {
+    return (
+        <Fragment>
+        <Layout>
+        <UserInfoLayout>
+        <div className="UserInfoLayoutTop">
+        {/* 유저 프로필 이미지 */}
+        <UserProfileImage src="https://avatars2.githubusercontent.com/u/56405613?s=460&u=b1dc8505bf966d1364e9aecce175deaa42d6f7f9&v=4"/>
+        <UserProfileInfo>
+        <div className="badge">매니저</div>
+        {/* 유저 닉네임 */}
+        <div className="userName">김어진</div>
+        </UserProfileInfo>
+        </div>
+        </UserInfoLayout>
+        <MyComment placeholder=""/>
+        <SubmitButton>등록</SubmitButton>
+        <CommentList/>
+        </Layout>
+        </Fragment>
+    )
+}
+
+export default CertificateTab
+const SubmitButton = styled.div`
+cursor: pointer;
+margin-top:20px;
+display:flex;
+justify-content:center;
+align-items:center;
+font-weight:bold;
+color: #6c51b4;
+font-size:16px;
+margin-left:auto;
+width:60px;
+height:40px;
+background-color: #f6f2fe;
+border-radius:5px;
+border:none;
+`
+const UserProfileInfo = styled.div`
+width:100%;
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:flex-start;
+.badge{
+    border: 1px solid #ff6178;
+    border-radius: 20px;
+    margin: 2px 0 4px;
+    padding: 0 5px;
+    font-size: 10px;
+    color: #ff6178;
+}
+.userName{
+    font-size:15px;
+    font-weight:bold;
+    color:#000;
+}
+`
+const UserProfileImage = styled.div`
+min-width:60px;
+min-height:60px;
+margin-right: 12px;
+border:1px solid #e5e5e5;
+border-radius:15px;
+box-sizing:border-box;
+background-image:url(${props=>props.src});
+background-position:center;
+background-repeat:no-repeat;
+background-size:100% auto;
+`
+const UserInfoLayout = styled.div`
+width:100%;
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:flex-start;
+.UserInfoLayoutTop{
+    display:flex;
+justify-content:flex-start;
+align-items:center;
+}
+`
+const MyComment = styled.textarea`
+outline:none;
+margin-top:20px;
+width:100%;
+height:100px;
+resize:none;
+padding:10px;
+border:1px solid #e5e5e5;
+border-radius:5px;
+box-sizing:border-box;
+&::placeholder{
+    color:#737373;
+    font-weight:bold;
+}
+`
+const Layout = styled.div`
+display:flex;
+flex-direction:column;
+justify-content:flex-start;
+align-items:center;
+width:100%;
+min-height:800px;
+padding:28px 20px;
+box-sizing:border-box;
+
+`

--- a/client/src/composition/StudyPages/StudyPageRead/CommentList.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/CommentList.tsx
@@ -1,0 +1,123 @@
+import React, { Fragment } from 'react'
+import styled from 'styled-components'
+
+function CommentList() {
+    const Dummy = [{user:"유재욱",comment:"출석완료!",image:"https://avatars1.githubusercontent.com/u/13144573?s=460&u=9042af1affd7da76dd24c6f12aa8660bdd4e42e5&v=4"},{user:"오승영",comment:"오~출석완료!",image:"https://avatars2.githubusercontent.com/u/46865281?s=460&u=9687af854c3f5ae8a8f8b1e4f10a87587eaf5626&v=4"},{user:"김어진",comment:"출석완료했습니다!",leader:true,image:"https://avatars2.githubusercontent.com/u/56405613?s=460&u=b1dc8505bf966d1364e9aecce175deaa42d6f7f9&v=4"}]
+    const RenderComments = Dummy.map((data,index)=>{
+        return(
+            <Fragment key={index}>
+            <UserCommentLayout>
+            <UserInfoLayout>
+            <div className="UserInfoLayoutTop">
+            {/* 유저 프로필 이미지 */}
+            <UserProfileImage src={data.image}/>
+            <UserProfileInfo>
+            {data.leader &&(
+            <div className="badge">매니저</div>
+            )}
+            {/* 유저 닉네임 */}
+            <div className="userName">{data.user}</div>
+            </UserProfileInfo>
+            </div>
+            </UserInfoLayout>
+            {/* 유저 댓글 */}
+            <CommentArea>{data.comment}</CommentArea>
+            </UserCommentLayout>
+            </Fragment>
+        )
+    })
+    return (
+        <Fragment>
+        <Layout>
+        <Title>💪🏻 오늘의 출석현황 
+        <div className="certificateNum">총 {Dummy.length}명</div>
+        </Title>
+{RenderComments}
+        </Layout>
+        </Fragment>
+    )
+}
+
+export default CommentList
+const UserCommentLayout = styled.div`
+margin-bottom:20px;
+width:100%;
+box-sizing:border-box;
+padding:16px 16px;
+border:1px solid #d3d3d3;
+border-radius:5px;
+`
+const CommentArea = styled.div`
+width:100%;
+font-size:16px;
+font-weight:bold;
+color: #6c51b4;
+
+`
+const UserProfileInfo = styled.div`
+width:100%;
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:flex-start;
+.badge{
+    border: 1px solid #ff6178;
+    border-radius: 20px;
+    margin: 2px 0 4px;
+    padding: 0 5px;
+    font-size: 10px;
+    color: #ff6178;
+}
+.userName{
+    font-size:15px;
+    font-weight:bold;
+    color:#000;
+}
+`
+const UserProfileImage = styled.div`
+min-width:60px;
+min-height:60px;
+margin-right: 12px;
+border:1px solid #e5e5e5;
+border-radius:15px;
+box-sizing:border-box;
+background-image:url(${props=>props.src});
+background-position:center;
+background-repeat:no-repeat;
+background-size:100% auto;
+`
+const UserInfoLayout = styled.div`
+margin-bottom:20px;
+width:100%;
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:flex-start;
+.UserInfoLayoutTop{
+    display:flex;
+justify-content:flex-start;
+align-items:center;
+}
+`
+const Title = styled.div`
+display:flex;
+justify-content:space-between;
+align-items:center;
+width:100%;
+font-size:20px;
+margin-bottom:20px;
+font-weight:bold;
+color:#000;
+.certificateNum{
+    font-size:16px;
+}
+`
+const Layout = styled.div`
+margin-top:40px;
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:flex-start;
+width:100%;
+
+`

--- a/client/src/composition/StudyPages/StudyPageRead/DeleteTab.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/DeleteTab.tsx
@@ -1,0 +1,98 @@
+import React, { Fragment,useState } from 'react'
+import styled,{ keyframes }from "styled-components"
+import DeleteModal from '../StudyPageDelete/DeleteModal'
+
+function DeleteTab() {
+    const [ModalOpen, setModalOpen] = useState(false)
+    return (
+        <Fragment>
+        <Layout>
+        <Title>스터디 관리 ⚙️</Title>
+        <SubmitButton onClick={()=>setModalOpen(!ModalOpen)}>스터디 탈퇴하기</SubmitButton>
+        </Layout>
+        <Fragment>
+            <BackGroundLayer ModalOpen={ModalOpen}>
+            <BackGround onClick={()=>setModalOpen(!ModalOpen)}>
+            </BackGround>
+            <DeleteModal ModalOpen={ModalOpen}/>
+            </BackGroundLayer>
+            </Fragment>
+        </Fragment>
+    )
+}
+
+export default DeleteTab
+const FadeIn = () => keyframes`
+from {
+    background-color: rgba(128, 128, 128,0);
+}
+to {
+    background-color: rgba(128, 128, 128,0.7);
+}
+`;
+const Fadeout = () => keyframes`
+from {
+    background-color: rgba(128, 128, 128,0.7);
+}
+to {
+    background-color: rgba(128, 128, 128,0);
+}
+`;
+const BackGroundLayer = styled.div`
+display:flex;
+justify-content:center;
+align-items:center;
+position:absolute;
+z-index:9998;
+bottom:0px;
+width:100%;
+height:100%;
+/* opacity:0.7; */
+/* background-color: #808080; */
+background-color: rgba(128, 128, 128,0.7);
+
+visibility: ${props => props.ModalOpen ? 'visible' : 'hidden'};
+animation: ${props => props.ModalOpen ? FadeIn : Fadeout} 0.5s linear;
+transition: visibility 0.5s linear;
+`
+const BackGround = styled.div`
+display:flex;
+justify-content:center;
+align-items:center;
+width:100%;
+height:100%;
+`
+const Title = styled.div`
+width:110px;
+text-align:left;
+border-bottom:2px solid #000;
+padding:0px 5px 5px 0px;
+box-sizing:border-box;
+font-size:18px;
+font-weight:bold;
+color:#000;
+`
+const SubmitButton = styled.div`
+cursor: pointer;
+margin-top:10px;
+display:flex;
+justify-content:center;
+align-items:center;
+font-weight:bold;
+color:#fff;
+font-size:12px;
+width:90px;
+height:40px;
+background-color:#ff6178;
+border-radius:5px;
+border:none;
+`
+const Layout = styled.div`
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:flex-start;
+width:100%;
+padding:28px 0px;
+box-sizing:border-box;
+`

--- a/client/src/composition/StudyPages/StudyPageRead/Header.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/Header.tsx
@@ -1,0 +1,78 @@
+import React, { Fragment } from 'react'
+import styled from 'styled-components'
+
+function Header() {
+    return (
+        <Fragment>
+        <Layout>
+        <BackgroundImage>
+        {/* 스터디 타이틀 */}
+        <StudyTitle>1일 1개 N행시로 센스력 키우기 🤟</StudyTitle>
+        <StudyInfoLayout>
+        <StudyMemberInfo>참여&nbsp;
+        {/* 참여인원 */}
+        <div className="boldText">48명</div>
+        </StudyMemberInfo>
+        {/* 인증률 */}
+        <StudyMemberInfo>인증률&nbsp;
+        <div className="boldText">75%</div>
+        </StudyMemberInfo>
+        </StudyInfoLayout>
+        </BackgroundImage>
+        </Layout>
+        </Fragment>
+    )
+}
+
+export default Header
+const StudyMemberInfo = styled.div`
+width:100%;
+height:16px;
+display:flex;
+justify-content:center;
+align-items:center;
+font-size: 12px;
+color:#fff;
+.boldText{
+    height:16px;
+    font-weight:bold;
+}
+`
+const StudyInfoLayout = styled.div`
+display:flex;
+justify-content:space-between;
+align-items:center;
+margin-top:25px;
+min-width:170px;
+min-height:30px;
+border:1px solid #fff;
+border-radius:15px;
+padding:0px 16px;
+box-sizing:border-box;
+.dot{
+    color:#fff;
+    height:16px;
+    margin-bottom:5px;
+    font-weight:bold;
+}
+`
+const StudyTitle = styled.div`
+font-size:23px;
+font-weight:bold;
+color:#fff;
+
+`
+const BackgroundImage = styled.div`
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:center;
+width:100%;
+min-height:200px;
+background-color:rgba(0,0,0,0.5);
+`
+const Layout = styled.div`
+width:100%;
+min-height:200px;
+box-sizing:border-box;
+`

--- a/client/src/composition/StudyPages/StudyPageRead/IntroduceTab.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/IntroduceTab.tsx
@@ -1,0 +1,15 @@
+import React, { Fragment } from 'react'
+import ManagerInfo from './ManagerInfo'
+import RenderList from './RenderList'
+import StudyDesc from './StudyDesc'
+function IntroduceTab() {
+    return (
+        <Fragment>
+        <ManagerInfo/>
+        <RenderList/>
+        <StudyDesc/>
+        </Fragment>
+    )
+}
+
+export default IntroduceTab

--- a/client/src/composition/StudyPages/StudyPageRead/ManagerInfo.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/ManagerInfo.tsx
@@ -1,0 +1,83 @@
+import React, { Fragment } from 'react'
+import styled from 'styled-components'
+
+function ManagerInfo() {
+    return (
+        <Fragment>
+        <Layout>
+        <UserInfoLayout>
+        <div className="UserInfoLayoutTop">
+        {/* 방장 프로필 이미지 */}
+        <UserProfileImage src="https://avatars2.githubusercontent.com/u/56405613?s=460&u=b1dc8505bf966d1364e9aecce175deaa42d6f7f9&v=4"/>
+        <UserProfileInfo>
+        <div className="badge">매니저</div>
+        {/* 방장 닉네임 */}
+        <div className="userName">블루베리</div>
+        </UserProfileInfo>
+        </div>
+        <div className="UserInfoLayoutBottom">
+        {/* 방장 소개 글 */}
+        <UserDesc>센스 만렙 찍고 싶은 애</UserDesc>
+        </div>
+        </UserInfoLayout>
+        </Layout>
+        </Fragment>
+    )
+}
+
+export default ManagerInfo
+const UserDesc = styled.div`
+margin-top:16px;
+width:100%;
+font-size:14px;
+color:#737373;
+`
+const UserProfileInfo = styled.div`
+width:100%;
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:flex-start;
+.badge{
+    border: 1px solid #ff6178;
+    border-radius: 20px;
+    margin: 2px 0 4px;
+    padding: 0 5px;
+    font-size: 10px;
+    color: #ff6178;
+}
+.userName{
+    font-size:15px;
+    font-weight:bold;
+    color:#000;
+}
+`
+const UserProfileImage = styled.div`
+min-width:60px;
+min-height:60px;
+margin-right: 12px;
+border:1px solid #e5e5e5;
+border-radius:15px;
+box-sizing:border-box;
+background-image:url(${props=>props.src});
+background-position:center;
+background-repeat:no-repeat;
+background-size:100% auto;
+`
+const UserInfoLayout = styled.div`
+width:100%;
+display:flex;
+flex-direction:column;
+justify-content:center;
+align-items:flex-start;
+.UserInfoLayoutTop{
+    display:flex;
+justify-content:flex-start;
+align-items:center;
+}
+`
+const Layout = styled.div`
+width:100%;
+padding:28px 20px 32px;
+box-sizing:border-box;
+`

--- a/client/src/composition/StudyPages/StudyPageRead/RenderList.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/RenderList.tsx
@@ -1,0 +1,59 @@
+import React,{Fragment} from 'react'
+import styled from 'styled-components'
+function RenderList() {
+    const Dummy = [{title:"인증방법",disc:"매일 제시되는 단어로 N행시 짓기, 텍스트로 인증!"}
+    ,{title:"인증시간",
+    disc:"매일 02:00 ~ 다음날 02:00"
+    }
+]
+    const RenderLists = Dummy.map((data,index)=>{
+        return(
+            <Fragment key={index}>
+            <div className="List">
+        <div className="ListTitle">{data.title}</div>
+        <div className="ListContent">{data.disc}</div>
+        </div>
+            </Fragment>
+        )
+    })
+    return (
+        <Fragment>
+        <DescLists>
+        {RenderLists}
+        </DescLists>
+        </Fragment>
+    )
+}
+
+export default RenderList
+const DescLists = styled.div`
+width:100%;
+padding:5px 20px;
+box-sizing:border-box;
+background-color: #f6f2fe;
+.List{
+    display:flex;
+    justify-content:flex-start;
+    align-items:center;
+    width:100%;
+    height:46px;
+    border-bottom:1px solid #e5e5e5;
+    padding:12px 0px;
+    line-height: 1.62;
+    color: #6c51b4;
+    box-sizing:border-box;
+    &:last-child{
+ border-bottom:none;
+}
+    .ListTitle{
+        min-width:45px;
+    font-weight: 400;
+    font-size: 13px;
+}
+.ListContent{
+    padding-left:10px;
+    font-weight: 900;
+    font-size: 14px;
+}
+}
+`

--- a/client/src/composition/StudyPages/StudyPageRead/StudyDesc.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/StudyDesc.tsx
@@ -1,0 +1,51 @@
+import React, { Fragment } from 'react'
+import styled from 'styled-components'
+
+function StudyDesc() {
+    return (
+        <Fragment>
+        <Layout>
+        <Article>
+        프로젝트 소개와 개설 이유
+        <br/>
+        <br/>
+센 : 센스도
+<br/>
+스 : 스-읍관이다 👻
+<br/>
+<br/>
+1일 1개 N행시로 굳어진 머리를 말랑말랑하게 해봐요!
+<br/>
+이런 분께 추천해요
+<br/>
+<br/>
+말장난 장인
+<br/>
+센스력 필수 마케터
+<br/>
+어째 머리가 굳은 분
+<br/>
+<br/>
+<br/>
+프로젝트 종료 후 기대되는 변화
+<br/>
+<br/>
+당신을 보는 누군가는 생각할 겁니다. "오.. 센스 장난없는데"
+        </Article>
+        </Layout>
+        </Fragment>
+    )
+}
+
+export default StudyDesc
+const Article = styled.div`
+width:100%;
+font-size:13px;
+font-weight:bold;
+color:#000;
+`
+const Layout = styled.div`
+width:100%;
+padding:36px 20px 58px;
+box-sizing:border-box;
+`

--- a/client/src/composition/StudyPages/StudyPageRead/StudyPageReadContainer.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/StudyPageReadContainer.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import StudyPageReadPresentation from './StudyPageReadPresentation'
+
+function StudyPageReadContainer() {
+    return (
+        <StudyPageReadPresentation/>
+    )
+}
+
+export default StudyPageReadContainer

--- a/client/src/composition/StudyPages/StudyPageRead/StudyPageReadPresentation.tsx
+++ b/client/src/composition/StudyPages/StudyPageRead/StudyPageReadPresentation.tsx
@@ -1,0 +1,65 @@
+import React, { Fragment,useState } from 'react'
+import styled from 'styled-components'
+import CertificateTab from './CertificateTab'
+import DeleteTab from './DeleteTab'
+import Header from './Header'
+import IntroduceTab from './IntroduceTab'
+
+
+function StudyPageReadPresentation() {
+const [tab, setTab] = useState(1)
+const admin = true
+    return (
+        <Fragment>
+        <Header/>
+        <Layout>
+        <TabSelectLayout>
+        <TabSelect onClick={()=>setTab(1)} tabState={tab} tab={1}>소개</TabSelect>
+        <TabSelect onClick={()=>setTab(2)} tabState={tab} tab={2}>인증하기</TabSelect>
+        <TabSelect onClick={()=>setTab(3)} tabState={tab} tab={3}>설정</TabSelect>
+        </TabSelectLayout>
+        {tab===1 &&(
+       <IntroduceTab/>)}
+       {tab===2 &&(
+        <CertificateTab/>)}
+        {tab===3 &&(
+            <DeleteTab/>)}
+        </Layout>
+        </Fragment>
+    )
+}
+
+export default StudyPageReadPresentation
+const TabSelect = styled.div`
+cursor: pointer;
+display:flex;
+justify-content:center;
+align-items:center;
+font-size:16px;
+font-weight:bold;
+width:100%;
+height:45px;
+color:${props=>props.tab===props.tabState ? "#000" : "#808080" };
+box-sizing:border-box;
+border-bottom:${props=>props.tab===props.tabState ? "2px solid #000" : "2px solid transparent"  };
+
+`
+const TabSelectLayout = styled.div`
+display:flex;
+justify-content:space-between;
+align-items:center;
+width:100%;
+height:45px;
+background-color:#fff;
+border-bottom:1px solid #d3d3d3;
+box-sizing:border-box;
+`
+const Layout = styled.div`
+display:flex;
+flex-direction:column;
+justify-content:flex-start;
+align-items:center;
+max-width:640px;
+max-height:100%;/* height:100%; */
+margin:0px auto 0px;
+`

--- a/client/src/composition/StudyPages/StudyPageUpdate/StudyPageUpdateContainer.tsx
+++ b/client/src/composition/StudyPages/StudyPageUpdate/StudyPageUpdateContainer.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import StudyPageCommon from '../StudyPageCommon'
+
+function StudyPageUpdateContainer() {
+
+    return (
+        <StudyPageCommon />
+    )
+}
+
+export default StudyPageUpdateContainer

--- a/client/src/pages/StudyPage/StudyPageRead/index.tsx
+++ b/client/src/pages/StudyPage/StudyPageRead/index.tsx
@@ -1,0 +1,2 @@
+import StudyPageReadContainer from "../../../composition/StudyPages/StudyPageRead/StudyPageReadContainer"
+export default StudyPageReadContainer

--- a/client/src/pages/StudyPage/StudyPageUpdate/index.tsx
+++ b/client/src/pages/StudyPage/StudyPageUpdate/index.tsx
@@ -1,0 +1,2 @@
+import StudyPageUpdateContainer from "../../../composition/StudyPages/StudyPageUpdate/StudyPageUpdateContainer"
+export default StudyPageUpdateContainer


### PR DESCRIPTION
### 스터디 프레젠테이션 Read

_상위 브렌치 체크아웃 미실시로 커밋 메세지가 중복되었습니다. 해당 PR외 다른 PR도 제일 하단 커밋 메세지만 확인하시면 됩니다. 죄송합니다ㅠㅠ_

![스터디 프레젠테이션 Read 스크린샷](https://user-images.githubusercontent.com/56405613/100532050-84a99700-323e-11eb-95bd-0d5375cce538.png)

**CertificatedTab.tsx**
- UserProfileImage src="..."에 대응 되는 이미지 삽입해주시면 됩니다.
- className "bedge"는 매니저인지 판단하는 로직 추가 후 조건문 리턴 하시면 됩니다.
- className "userName"에 유저명 넣어주시면 됩니다.
- 다른 컴포넌트에는 해당 되는 데이터를 주석처리로 표기 하였습니다.

**CommentList.tsx**
- Dummy 배열과 같이 받아온 데이터를 RenderComments를 통해 렌더링 해주시면 됩니다.

**DeleteTab.tsx**
```
<BackGroundLayer ModalOpen={ModalOpen}>
             <BackGround onClick={()=>setModalOpen(!ModalOpen)}>
             </BackGround>
             <DeleteModal ModalOpen={ModalOpen}/> // 대응 되는 모달 창
</BackGroundLayer>
```
- 위 모달 코드는 추후에 협의 후 공통 컴포넌트로 뺄 예정입니다.

**RenderList.tsx**
```
const Dummy = [{title:"인증방법",disc:"매일 제시되는 단어로 N행시 짓기, 텍스트로 인증!"}
     ,{title:"인증시간",
     disc:"매일 02:00 ~ 다음날 02:00"
     }]
```

- 임시로 더미 배열 렌더링 했습니다. 추후에 요청받은 배열을 RanderLists에 대입해주시면 됩니다.

**StudyDesc.tsx**
- Artilcle 태그에 마크다운 방식으로 추가 될 예정입니다.

**StudyPageReadPresentation.tsx**
- TabSelect 클릭으로 해당되는 탭이 표시 됩니다.


