### PR TITLE
Feat/registration container

### DIFF
--- a/client/src/composition/Signout/index.tsx
+++ b/client/src/composition/Signout/index.tsx
@@ -1,0 +1,4 @@
+export const Signout = () => {
+  window.localStorage.setItem('token', '');
+  alert('로그아웃 됐습니다.');
+};

--- a/client/src/modules/SignInModule/actions.ts
+++ b/client/src/modules/SignInModule/actions.ts
@@ -1,0 +1,28 @@
+import { loginApiProps } from './api';
+
+export const LOGIN_REQUEST = 'login/LOGIN_REQUEST';
+export const LOGIN_SUCCESS = 'login/LOGIN_SUCCESS';
+export const LOGIN_ERROR = 'login/LOGIN_ERROR';
+
+export const loginRequest = (form) => {
+  return {
+    type: 'LOGIN_REQUEST',
+    payload: form,
+  };
+};
+
+export const loginSuccess = (loginData: loginApiProps) => {
+  window.localStorage.setItem('token', loginData['JWT token']);
+  return {
+    type: 'LOGIN_SUCCESS',
+    payload: loginData,
+  };
+};
+
+export const loginError = (error) => {
+  alert('아이디 혹은 비밀번호를 확인해주세요.');
+  return {
+    type: 'LOGIN_ERROR',
+    error,
+  };
+};

--- a/client/src/modules/SignInModule/api.ts
+++ b/client/src/modules/SignInModule/api.ts
@@ -1,0 +1,18 @@
+import Api from '../axiosConfig';
+export async function loginApi(form: any) {
+  const response = await Api.post('/auth_user', {
+    auth: form,
+  });
+  console.log(response);
+  return response.data;
+}
+
+export interface loginApiProps {
+  'JWT token': string;
+  userInfo: UserInfo;
+}
+
+interface UserInfo {
+  id: number;
+  email: string;
+}

--- a/client/src/modules/SignInModule/index.ts
+++ b/client/src/modules/SignInModule/index.ts
@@ -2,4 +2,3 @@ export { default } from './reducer';
 export * from './actions';
 export * from './types';
 export * from './sagas';
-//

--- a/client/src/modules/SignInModule/reducer.ts
+++ b/client/src/modules/SignInModule/reducer.ts
@@ -1,0 +1,27 @@
+const login = (state = {}, action) => {
+  switch (action.type) {
+    case 'LOGIN_REQUEST':
+      return {
+        ...state,
+        loginStatus: { loading: true, error: null, data: null },
+      };
+    case 'LOGIN_SUCCESS':
+      return {
+        ...state,
+        loginStatus: {
+          loading: false,
+          error: null,
+          data: action.payload.userInfo,
+        },
+      };
+    case 'LOGIN_ERROR':
+      return {
+        ...state,
+        loginStatus: { loading: false, error: action.payload, data: null },
+      };
+    default:
+      return state;
+  }
+};
+
+export default login;

--- a/client/src/modules/SignInModule/sagas.ts
+++ b/client/src/modules/SignInModule/sagas.ts
@@ -1,0 +1,17 @@
+import { loginRequest, loginSuccess, loginError } from './actions';
+import { call, put, takeEvery } from 'redux-saga/effects';
+import { loginApi } from './api';
+import history from '../history';
+function* loginFuncSaga(action: ReturnType<typeof loginRequest>) {
+  try {
+    const loginData = yield call(loginApi, action.payload);
+    yield put(loginSuccess(loginData));
+    yield call([history, history.push], '/');
+  } catch (e) {
+    yield put(loginError(e));
+  }
+}
+export function* loginSaga() {
+  // yield all(loginSaga);
+  yield takeEvery('LOGIN_REQUEST', loginFuncSaga);
+}

--- a/client/src/modules/SignInModule/types.ts
+++ b/client/src/modules/SignInModule/types.ts
@@ -1,9 +1,9 @@
 import * as actions from './actions';
 
 export type LoginAction =
-  | ReturnType<typeof actions.signUpRequest>
-  | ReturnType<typeof actions.signUpSuccess>
-  | ReturnType<typeof actions.signUpError>;
+  | ReturnType<typeof actions.loginRequest>
+  | ReturnType<typeof actions.loginSuccess>
+  | ReturnType<typeof actions.loginError>;
 export type LoginState = {
   loginStatus: {
     loading: boolean;
@@ -11,4 +11,3 @@ export type LoginState = {
     error: Error | null;
   };
 };
-//

--- a/client/src/modules/SignUpModule/actions.ts
+++ b/client/src/modules/SignUpModule/actions.ts
@@ -25,3 +25,4 @@ export const signUpError = (error) => {
     error,
   };
 };
+//

--- a/client/src/modules/SignUpModule/actions.ts
+++ b/client/src/modules/SignUpModule/actions.ts
@@ -1,0 +1,27 @@
+export const SIGNUP_REQUEST = 'signup/SignUp_REQUEST';
+export const SIGNUP_SUCCESS = 'signup/SignUp_SUCCESS';
+export const SIGNUP_ERROR = 'signup/SignUp_ERROR';
+
+export const signUpRequest = (form) => {
+  return {
+    type: 'SIGNUP_REQUEST',
+    payload: form,
+  };
+};
+
+export const signUpSuccess = (signUpData) => {
+  alert('회원가입이 완료되었습니다.');
+  return {
+    type: 'SIGNUP_SUCCESS',
+    payload: signUpData,
+  };
+};
+
+export const signUpError = (error) => {
+  alert('회원가입 실패');
+  console.log(error);
+  return {
+    type: 'SIGNUP_ERROR',
+    error,
+  };
+};

--- a/client/src/modules/SignUpModule/api.ts
+++ b/client/src/modules/SignUpModule/api.ts
@@ -4,3 +4,4 @@ export async function signUpApi(form: any) {
   // console.log(response);
   return response.data;
 }
+//

--- a/client/src/modules/SignUpModule/api.ts
+++ b/client/src/modules/SignUpModule/api.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+export async function signUpApi(form: any) {
+  const response = await axios.post('/users', form);
+  // console.log(response);
+  return response.data;
+}

--- a/client/src/modules/SignUpModule/index.ts
+++ b/client/src/modules/SignUpModule/index.ts
@@ -1,0 +1,4 @@
+export { default } from './reducer';
+export * from './actions';
+export * from './types';
+export * from './sagas';

--- a/client/src/modules/SignUpModule/reducer.ts
+++ b/client/src/modules/SignUpModule/reducer.ts
@@ -1,0 +1,23 @@
+const login = (state = {}, action) => {
+  switch (action.type) {
+    case 'SIGNUP_REQUEST':
+      return {
+        ...state,
+        signUpStatus: { success: false },
+      };
+    case 'SIGNUP_SUCCESS':
+      return {
+        ...state,
+        signUpStatus: { success: true },
+      };
+    case 'SIGNUP_ERROR':
+      return {
+        ...state,
+        signUpStatus: { success: false, error: action.payload },
+      };
+    default:
+      return state;
+  }
+};
+
+export default login;

--- a/client/src/modules/SignUpModule/reducer.ts
+++ b/client/src/modules/SignUpModule/reducer.ts
@@ -21,3 +21,4 @@ const login = (state = {}, action) => {
 };
 
 export default login;
+//

--- a/client/src/modules/SignUpModule/sagas.ts
+++ b/client/src/modules/SignUpModule/sagas.ts
@@ -14,3 +14,4 @@ function* signUpFuncSaga(action: ReturnType<typeof signUpRequest>) {
 export function* signUpSaga() {
   yield takeEvery('SIGNUP_REQUEST', signUpFuncSaga);
 }
+//

--- a/client/src/modules/SignUpModule/sagas.ts
+++ b/client/src/modules/SignUpModule/sagas.ts
@@ -1,0 +1,16 @@
+import { signUpSuccess, signUpError, signUpRequest } from './actions';
+import { call, put, takeEvery } from 'redux-saga/effects';
+import { signUpApi } from './api';
+import history from '../history';
+function* signUpFuncSaga(action: ReturnType<typeof signUpRequest>) {
+  try {
+    const signUpData = yield call(signUpApi, action.payload);
+    yield put(signUpSuccess(signUpData));
+    yield call([history, history.push], '/signin');
+  } catch (e) {
+    yield put(signUpError(e));
+  }
+}
+export function* signUpSaga() {
+  yield takeEvery('SIGNUP_REQUEST', signUpFuncSaga);
+}

--- a/client/src/modules/SignUpModule/types.ts
+++ b/client/src/modules/SignUpModule/types.ts
@@ -1,0 +1,13 @@
+import * as actions from './actions';
+
+export type LoginAction =
+  | ReturnType<typeof actions.signUpRequest>
+  | ReturnType<typeof actions.signUpSuccess>
+  | ReturnType<typeof actions.signUpError>;
+export type LoginState = {
+  loginStatus: {
+    loading: boolean;
+    data: any | null;
+    error: Error | null;
+  };
+};

--- a/client/src/modules/axiosConfig.ts
+++ b/client/src/modules/axiosConfig.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+const Api = axios.create();
+// client.defaults.baseURL = 'https://external-api-server.com/';
+const Token = window.localStorage.getItem('token');
+console.log(Token);
+Api.defaults.headers.common['Authorization'] = Token ? Token : 'none';
+export default Api;
+//

--- a/client/src/modules/history.ts
+++ b/client/src/modules/history.ts
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+
+export default createBrowserHistory();

--- a/client/src/modules/history.ts
+++ b/client/src/modules/history.ts
@@ -1,3 +1,4 @@
 import { createBrowserHistory } from 'history';
 
 export default createBrowserHistory();
+//

--- a/client/src/modules/index.ts
+++ b/client/src/modules/index.ts
@@ -14,3 +14,4 @@ export type RootState = ReturnType<typeof rootReducer>;
 export function* rootSaga() {
   yield all([loginSaga(), signUpSaga()]);
 }
+//

--- a/client/src/modules/index.ts
+++ b/client/src/modules/index.ts
@@ -1,0 +1,16 @@
+import { combineReducers } from 'redux';
+import login, { loginSaga } from './SignInModule';
+import signUp, { signUpSaga } from './SignUpModule';
+import { all } from 'redux-saga/effects';
+
+const rootReducer = combineReducers({
+  login,
+  signUp,
+});
+
+export default rootReducer;
+export type RootState = ReturnType<typeof rootReducer>;
+
+export function* rootSaga() {
+  yield all([loginSaga(), signUpSaga()]);
+}

--- a/client/src/pages/SignupPage/SignupContainer.tsx
+++ b/client/src/pages/SignupPage/SignupContainer.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import SignupPresentation from './SignupPresentation';
+import { signUpRequest } from '../../modules/SignUpModule';
+
+function SignupContainer(): JSX.Element {
+  const dispatch = useDispatch();
+  const [form, setForm] = useState({
+    email: '',
+    password: '',
+    passwordConfirmation: '',
+  });
+  const { email, password, passwordConfirmation } = form;
+
+  const onSubmit = (email: string, password: string) => {
+    const signUpForm = { email: email, password: password };
+    dispatch(signUpRequest(signUpForm));
+    // if (password === passwordConfirmation) {
+    //   axios
+    //     .post('/users', {
+    //       email: email,
+    //       password: password,
+    //     })
+    //     .then((response) => {
+    //       console.log(response.data.message);
+    //       if (response.data.message === 'invalid email or password') {
+    //         alert('사용할 수 없는 아이디 혹은 패스워드입니다.');
+    //       } else {
+    //         history.push('/signin');
+    //       }
+    //     })
+    //     .catch((error) => {
+    //       console.log(error);
+    //     });
+    // } else {
+    //   alert('패스워드가 일치하지 않습니다.');
+    // }
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const { name, value } = e.target;
+    setForm({
+      ...form,
+      [name]: value,
+    });
+  };
+
+  const handleSubmit = (e): void => {
+    e.preventDefault();
+    onSubmit(email, password);
+  };
+
+  return (
+    <SignupPresentation
+      email={email}
+      password={password}
+      passwordConfirmation={passwordConfirmation}
+      onChange={onChange}
+      handleSubmit={handleSubmit}
+    />
+  );
+}
+export default SignupContainer;


### PR DESCRIPTION
**회원가입 리덕스 사가 적용**

폴더 구조는 아래와 같습니다.

![스크린샷 2020-12-07 오전 12 01 25](https://user-images.githubusercontent.com/56405613/101283690-59ffa580-381f-11eb-9e89-eb9a2375afe3.png)

리덕스-사가 & History 적용

```
import { createBrowserHistory } from 'history';
export default createBrowserHistory();

// modules/history.ts

import { signUpSuccess, signUpError, signUpRequest } from './actions';
import { call, put, takeEvery } from 'redux-saga/effects';
import { signUpApi } from './api';
import history from '../history'; // history import
function* signUpFuncSaga(action: ReturnType<typeof signUpRequest>) {
  try {
    const signUpData = yield call(signUpApi, action.payload);
    yield put(signUpSuccess(signUpData));
yield call([history, history.push], '/signin'); // 여기에서 해당 라우트 주소 넣어서 사용하시면 됩니다.
  } catch (e) {
    yield put(signUpError(e));
  }
}
export function* signUpSaga() {
  yield takeEvery('SIGNUP_REQUEST', signUpFuncSaga);
}

// modules/SignUpModule/sagas.ts
```

추가 내용
@ppamppamman 

![스크린샷 2020-12-07 오전 12 05 10](https://user-images.githubusercontent.com/56405613/101283762-e27e4600-381f-11eb-8022-93654083f8bd.png)
![스크린샷 2020-12-07 오전 12 06 25](https://user-images.githubusercontent.com/56405613/101283784-0fcaf400-3820-11eb-8036-e61d32b43110.png)

재욱님 

- 위 사가 코드와 같이 에러캐치하는 부분을 분기했는데, 요청 실패시에도 status 200으로 반환하고, 에러메세지에 "invalid email or password"로 나와서 실패시 status 401로 변경해주시면 감사하겠습니다.

- 한가지 더 부탁 드리고 싶은건 이메일 중복인지, 이메일 및 패스워드 양식 에러인지 따로 판단하게 status 따로 만들어 주실 수 있을까요?